### PR TITLE
Added updated dashboard for combined view

### DIFF
--- a/aks/combined_view.json
+++ b/aks/combined_view.json
@@ -108,7 +108,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_uname_info{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_uname_info{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -374,7 +374,7 @@
           },
           "editorMode": "code",
           "expr": "100 - (node_filesystem_avail_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -456,8 +456,10 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -540,7 +542,7 @@
           },
           "editorMode": "code",
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -644,7 +646,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\" }[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -746,7 +748,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_cpu_scaling_frequency_hertz{instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"} / 1000000",
+          "expr": "node_cpu_frequency_hertz{instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"} / 1000000",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -850,7 +852,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\", cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -953,7 +955,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -1062,7 +1064,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -1165,7 +1167,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"}",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -1275,7 +1277,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"$instance\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -1286,7 +1288,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
@@ -1389,7 +1391,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"${instance}\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -1503,7 +1505,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_reads_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - reads completed",
           "range": true,
           "refId": "A"
@@ -1514,7 +1516,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_writes_completed_total{instance=\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - writes completed",
           "range": true,
           "refId": "B"
@@ -1628,7 +1630,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} -read",
           "range": true,
           "refId": "A"
@@ -1639,7 +1641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - write",
           "range": true,
           "refId": "B"
@@ -1753,7 +1755,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - {{operation}}s completed",
           "range": true,
           "refId": "A"
@@ -1764,7 +1766,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{export}} - {{operation}}s completed",
@@ -1880,7 +1882,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - read",
           "range": true,
           "refId": "A"
@@ -1891,7 +1893,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - write",
           "range": true,
           "refId": "B"
@@ -1944,7 +1946,19 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Values"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -1965,12 +1979,7 @@
         },
         "frameIndex": 0,
         "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "node_uname_info"
-          }
-        ]
+        "sortBy": []
       },
       "pluginVersion": "11.2.8",
       "targets": [
@@ -1980,7 +1989,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{hostname=\"$instance\", cluster=\"$cluster\", gpu=\"0\"}",
+          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=\"0\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2080,7 +2089,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(dcgm_fi_dev_gpu_util{hostname=~\"$instance\", cluster=\"$cluster\"})",
+          "expr": "avg(dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2154,7 +2163,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_power_usage{hostname=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{hostname=~\"$instance\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
+          "expr": "avg ((dcgm_fi_dev_power_usage{hostname=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{hostname=~\"^$instance$\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -2228,7 +2237,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_gpu_temp{hostname=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{hostname=~\"$instance\",cluster=\"$cluster\"}) * 100) ",
+          "expr": "avg ((dcgm_fi_dev_gpu_temp{hostname=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{hostname=~\"^$instance$\",cluster=\"$cluster\"}) * 100) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2317,7 +2326,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{hostname=\"$instance\", cluster=\"$cluster\"})",
+          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{hostname=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "{{gpu}}",
           "range": true,
           "refId": "A"
@@ -2423,7 +2432,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2529,7 +2538,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_copy_util{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_copy_util{hostname=\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2632,7 +2641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_sm_clock{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_sm_clock{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2703,7 +2712,32 @@
           },
           "unit": "MHz"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "GPU 0"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -2735,7 +2769,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_clock{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_clock{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2839,7 +2873,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2943,7 +2977,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3014,7 +3048,32 @@
           },
           "unit": "watt"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "GPU 0"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -3047,7 +3106,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3150,7 +3209,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_total_energy_consumption{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"} / 10^3",
+          "expr": "dcgm_fi_dev_total_energy_consumption{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"} / 10^3",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3264,7 +3323,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{hostname=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{hostname=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -3486,7 +3545,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{hostname=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{hostname=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -3705,7 +3764,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3871,7 +3930,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4036,7 +4095,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4202,7 +4261,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4338,7 +4397,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4440,7 +4499,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4560,7 +4619,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_active{hostname=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_active{hostname=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4667,7 +4726,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_sm_occupancy{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_sm_occupancy{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4774,7 +4833,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_tensor_active{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_tensor_active{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4881,7 +4940,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp16_active{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp16_active{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4988,7 +5047,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp32_active{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp32_active{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5095,7 +5154,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_prof_pipe_fp64_active{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_prof_pipe_fp64_active{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5213,7 +5272,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_rx_bytes{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -5224,7 +5283,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_pcie_tx_bytes{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -5364,7 +5423,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_infiniband_physical_state_id{instance=~\"$instance\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
+          "expr": "node_infiniband_physical_state_id{instance=~\"^$instance$\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5466,7 +5525,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=\"$instance\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=~\"^$instance$\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5583,7 +5642,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{device}} - receive",
           "range": true,
@@ -5595,7 +5654,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$instance\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{device}} - transmit",
@@ -5698,7 +5757,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5799,7 +5858,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5900,7 +5959,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6001,7 +6060,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6102,7 +6161,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -6231,7 +6290,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{hostname=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{hostname=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -6453,7 +6512,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{hostname=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6606,7 +6665,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{hostname=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -6617,7 +6676,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{hostname=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{hostname=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -6751,7 +6810,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{hostname=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{hostname=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6917,7 +6976,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{hostname=~\"$instance\", cluster=\"$cluster\",gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{hostname=~\"^$instance$\", cluster=\"$cluster\",gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6991,7 +7050,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "da-hpc-cluster",
           "value": "da-hpc-cluster"
         },
@@ -7124,7 +7183,7 @@
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"}, gpu)",
+        "definition": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"},gpu)",
         "hide": 0,
         "includeAll": true,
         "label": "GPU",
@@ -7132,8 +7191,9 @@
         "name": "gpu",
         "options": [],
         "query": {
-          "query": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"}, gpu)",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"},gpu)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -7144,8 +7204,8 @@
       {
         "current": {
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",debug_node_name=\"aks-hpcsku-28720227-vmss000000\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"aks-hpcsku-28720227-vmss000000\",job=\"kube-system/nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_container_id=\"containerd://524c5ed9e86f502c27394558b0f8d31bc6d5142436479dfd4c0c04bee399d21d\",pod_container_image=\"nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04\",pod_container_init=\"false\",pod_container_name=\"exporter\",pod_container_port_name=\"metrics\",pod_container_port_number=\"9400\",pod_container_port_protocol=\"tcp\",pod_controller_kind=\"daemonset\",pod_controller_name=\"dcgm-nvidia-dcgm-exporter\",pod_host_ip=\"10.224.0.4\",pod_ip=\"10.244.4.112\",pod_labelpresent_app_kubernetes_io_component=\"true\",pod_labelpresent_app_kubernetes_io_instance=\"true\",pod_labelpresent_app_kubernetes_io_name=\"true\",pod_labelpresent_controller_revision_hash=\"true\",pod_labelpresent_pod_template_generation=\"true\",pod_label_app_kubernetes_io_component=\"dcgm-exporter\",pod_label_app_kubernetes_io_instance=\"dcgm-nvidia\",pod_label_app_kubernetes_io_name=\"dcgm-exporter\",pod_label_controller_revision_hash=\"78dc84884\",pod_label_pod_template_generation=\"1\",pod_name=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_node_name=\"aks-hpcsku-28720227-vmss000000\",pod_phase=\"running\",pod_ready=\"true\",pod_uid=\"b8433835-3063-4310-aefe-8bdfb6ad0e6d\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",debug_node_name=\"aks-hpcsku-28720227-vmss000000\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"aks-hpcsku-28720227-vmss000000\",job=\"kube-system/nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_container_id=\"containerd://524c5ed9e86f502c27394558b0f8d31bc6d5142436479dfd4c0c04bee399d21d\",pod_container_image=\"nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04\",pod_container_init=\"false\",pod_container_name=\"exporter\",pod_container_port_name=\"metrics\",pod_container_port_number=\"9400\",pod_container_port_protocol=\"tcp\",pod_controller_kind=\"daemonset\",pod_controller_name=\"dcgm-nvidia-dcgm-exporter\",pod_host_ip=\"10.224.0.4\",pod_ip=\"10.244.4.112\",pod_labelpresent_app_kubernetes_io_component=\"true\",pod_labelpresent_app_kubernetes_io_instance=\"true\",pod_labelpresent_app_kubernetes_io_name=\"true\",pod_labelpresent_controller_revision_hash=\"true\",pod_labelpresent_pod_template_generation=\"true\",pod_label_app_kubernetes_io_component=\"dcgm-exporter\",pod_label_app_kubernetes_io_instance=\"dcgm-nvidia\",pod_label_app_kubernetes_io_name=\"dcgm-exporter\",pod_label_controller_revision_hash=\"78dc84884\",pod_label_pod_template_generation=\"1\",pod_name=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_node_name=\"aks-hpcsku-28720227-vmss000000\",pod_phase=\"running\",pod_ready=\"true\",pod_uid=\"b8433835-3063-4310-aefe-8bdfb6ad0e6d\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}"
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"10.244.4.112:9400\",job=\"dcgm-nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",service=\"dcgm-nvidia-dcgm-exporter\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"10.244.4.112:9400\",job=\"dcgm-nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",service=\"dcgm-nvidia-dcgm-exporter\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -7170,15 +7230,16 @@
       },
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",debug_node_name=\"aks-hpcsku-28720227-vmss000000\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"aks-hpcsku-28720227-vmss000000\",job=\"kube-system/nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_container_id=\"containerd://524c5ed9e86f502c27394558b0f8d31bc6d5142436479dfd4c0c04bee399d21d\",pod_container_image=\"nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04\",pod_container_init=\"false\",pod_container_name=\"exporter\",pod_container_port_name=\"metrics\",pod_container_port_number=\"9400\",pod_container_port_protocol=\"tcp\",pod_controller_kind=\"daemonset\",pod_controller_name=\"dcgm-nvidia-dcgm-exporter\",pod_host_ip=\"10.224.0.4\",pod_ip=\"10.244.4.112\",pod_labelpresent_app_kubernetes_io_component=\"true\",pod_labelpresent_app_kubernetes_io_instance=\"true\",pod_labelpresent_app_kubernetes_io_name=\"true\",pod_labelpresent_controller_revision_hash=\"true\",pod_labelpresent_pod_template_generation=\"true\",pod_label_app_kubernetes_io_component=\"dcgm-exporter\",pod_label_app_kubernetes_io_instance=\"dcgm-nvidia\",pod_label_app_kubernetes_io_name=\"dcgm-exporter\",pod_label_controller_revision_hash=\"78dc84884\",pod_label_pod_template_generation=\"1\",pod_name=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_node_name=\"aks-hpcsku-28720227-vmss000000\",pod_phase=\"running\",pod_ready=\"true\",pod_uid=\"b8433835-3063-4310-aefe-8bdfb6ad0e6d\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}",
-          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",debug_node_name=\"aks-hpcsku-28720227-vmss000000\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"aks-hpcsku-28720227-vmss000000\",job=\"kube-system/nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_container_id=\"containerd://524c5ed9e86f502c27394558b0f8d31bc6d5142436479dfd4c0c04bee399d21d\",pod_container_image=\"nvcr.io/nvidia/k8s/dcgm-exporter:4.2.3-4.1.3-ubuntu22.04\",pod_container_init=\"false\",pod_container_name=\"exporter\",pod_container_port_name=\"metrics\",pod_container_port_number=\"9400\",pod_container_port_protocol=\"tcp\",pod_controller_kind=\"daemonset\",pod_controller_name=\"dcgm-nvidia-dcgm-exporter\",pod_host_ip=\"10.224.0.4\",pod_ip=\"10.244.4.112\",pod_labelpresent_app_kubernetes_io_component=\"true\",pod_labelpresent_app_kubernetes_io_instance=\"true\",pod_labelpresent_app_kubernetes_io_name=\"true\",pod_labelpresent_controller_revision_hash=\"true\",pod_labelpresent_pod_template_generation=\"true\",pod_label_app_kubernetes_io_component=\"dcgm-exporter\",pod_label_app_kubernetes_io_instance=\"dcgm-nvidia\",pod_label_app_kubernetes_io_name=\"dcgm-exporter\",pod_label_controller_revision_hash=\"78dc84884\",pod_label_pod_template_generation=\"1\",pod_name=\"dcgm-nvidia-dcgm-exporter-9cvzq\",pod_node_name=\"aks-hpcsku-28720227-vmss000000\",pod_phase=\"running\",pod_ready=\"true\",pod_uid=\"b8433835-3063-4310-aefe-8bdfb6ad0e6d\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",hostname=\"$instance\"}",
+        "definition": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",instance=\"$instance\"}",
         "hide": 2,
         "includeAll": false,
         "multi": false,
@@ -7186,7 +7247,7 @@
         "options": [],
         "query": {
           "qryType": 5,
-          "query": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",hostname=\"$instance\"}",
+          "query": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",instance=\"$instance\"}",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -7206,7 +7267,7 @@
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", hostname=\"$instance\"},physical_host)",
+        "definition": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", instance=\"$instance\"},physical_host)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
@@ -7214,7 +7275,7 @@
         "options": [],
         "query": {
           "qryType": 5,
-          "query": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", hostname=\"$instance\"},physical_host)",
+          "query": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", instance=\"$instance\"},physical_host)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/aks/combined_view_without_gpu_profiling.json
+++ b/aks/combined_view_without_gpu_profiling.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
+  "id": 61,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -108,7 +108,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_uname_info{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_uname_info{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -374,7 +374,7 @@
           },
           "editorMode": "code",
           "expr": "100 - (node_filesystem_avail_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\", cluster=\"$cluster\"} * 100) / node_filesystem_size_bytes{instance=\"$instance\",mountpoint=\"/\",fstype!=\"rootfs\",cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -456,8 +456,10 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -540,7 +542,7 @@
           },
           "editorMode": "code",
           "expr": "node_time_seconds{instance=\"$instance\", cluster=\"$cluster\"} - node_boot_time_seconds{instance=\"$instance\", cluster=\"$cluster\"}",
-          "format": "time_series",
+          "format": "table",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -644,7 +646,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\" }[$__rate_interval]))))",
+          "expr": "(100 * (1 - avg by (hostname, cpu) (rate(node_cpu_seconds_total{mode='idle', instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\" }[$__rate_interval]))))",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -746,7 +748,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_cpu_scaling_frequency_hertz{instance=~\"$instance\", cpu=~\"$cpu\", cluster=\"$cluster\"} / 1000000",
+          "expr": "node_cpu_frequency_hertz{instance=~\"^$instance$\", cpu=~\"^$cpu$\", cluster=\"$cluster\"} / 1000000",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -850,7 +852,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"$instance\", cluster=\"$cluster\"}))",
+          "expr": "(100 * (1 - node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"} / node_memory_memtotal_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "range": true,
@@ -953,7 +955,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_memory_memavailable_bytes{instance=~\"$instance\", cluster=\"$cluster\"}",
+          "expr": "node_memory_memavailable_bytes{instance=~\"^$instance$\", cluster=\"$cluster\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -1062,7 +1064,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_vmstat_pgmajfault{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -1165,7 +1167,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=\"${instance}\",device!~\"rootfs\", cluster=\"$cluster\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"} - node_filesystem_avail_bytes{instance=~\"^$instance$\",device!~\"rootfs\", cluster=\"$cluster\"}",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -1275,7 +1277,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"$instance\", cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_receive_bytes_total{device='eth0', instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{instance}} - receive",
           "range": true,
           "refId": "A"
@@ -1286,7 +1288,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"$instance\",cluster=\"$cluster\"}[$__rate_interval]))",
+          "expr": "(rate(node_network_transmit_bytes_total{device='eth0', instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{instance}} - transmit",
@@ -1389,7 +1391,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"${instance}\",device=~\"$diskdevices\", cluster=\"$cluster\"} [$__rate_interval])",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"} [$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -1503,7 +1505,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_reads_completed_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - reads completed",
           "range": true,
           "refId": "A"
@@ -1514,7 +1516,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_writes_completed_total{instance=\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - writes completed",
           "range": true,
           "refId": "B"
@@ -1628,7 +1630,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\",device=~\"$diskdevices\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_read_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} -read",
           "range": true,
           "refId": "A"
@@ -1639,7 +1641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_disk_written_bytes_total{instance=\"$instance\",device=~\"$diskdevices\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_disk_written_bytes_total{instance=~\"^$instance$\",device=~\"^$diskdevices$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{device}} - write",
           "range": true,
           "refId": "B"
@@ -1753,7 +1755,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^READ$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - {{operation}}s completed",
           "range": true,
           "refId": "A"
@@ -1764,7 +1766,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=\"$instance\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_operations_requests_total{instance=~\"^$instance$\", operation=~\"^WRITE$\",cluster=\"$cluster\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{export}} - {{operation}}s completed",
@@ -1880,7 +1882,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=\"$instance\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_read_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - read",
           "range": true,
           "refId": "A"
@@ -1891,7 +1893,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "irate(node_mountstats_nfs_total_write_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "{{export}} - write",
           "range": true,
           "refId": "B"
@@ -1944,7 +1946,19 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Values"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -1965,12 +1979,7 @@
         },
         "frameIndex": 0,
         "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "node_uname_info"
-          }
-        ]
+        "sortBy": []
       },
       "pluginVersion": "11.2.8",
       "targets": [
@@ -1980,7 +1989,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{hostname=\"$instance\", cluster=\"$cluster\", gpu=\"0\"}",
+          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=\"0\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2080,7 +2089,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(dcgm_fi_dev_gpu_util{hostname=~\"$instance\", cluster=\"$cluster\"})",
+          "expr": "avg(dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2154,7 +2163,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_power_usage{hostname=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{hostname=~\"$instance\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
+          "expr": "avg ((dcgm_fi_dev_power_usage{hostname=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_power_mgmt_limit{hostname=~\"^$instance$\",cluster=\"$cluster\"}) * 100)\r\n\r\n",
           "legendFormat": "CPU {{cpu}}",
           "range": true,
           "refId": "A"
@@ -2228,7 +2237,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "avg ((dcgm_fi_dev_gpu_temp{hostname=~\"$instance\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{hostname=~\"$instance\",cluster=\"$cluster\"}) * 100) ",
+          "expr": "avg ((dcgm_fi_dev_gpu_temp{hostname=~\"^$instance$\",cluster=\"$cluster\"} / dcgm_fi_dev_gpu_max_op_temp{hostname=~\"^$instance$\",cluster=\"$cluster\"}) * 100) ",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2317,7 +2326,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{hostname=\"$instance\", cluster=\"$cluster\"})",
+          "expr": "max by (gpu) (dcgm_fi_dev_xid_errors{hostname=~\"^$instance$\", cluster=\"$cluster\"})",
           "legendFormat": "{{gpu}}",
           "range": true,
           "refId": "A"
@@ -2423,7 +2432,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"$instance\", gpu=~\"$gpu\", cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_util{hostname=~\"^$instance$\", gpu=~\"^$gpu$\", cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2529,7 +2538,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_copy_util{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_copy_util{hostname=\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2632,7 +2641,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_sm_clock{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_sm_clock{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2703,7 +2712,32 @@
           },
           "unit": "MHz"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "GPU 0"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -2735,7 +2769,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_mem_clock{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_mem_clock{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2839,7 +2873,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_gpu_temp{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_gpu_temp{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -2943,7 +2977,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_memory_temp{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_memory_temp{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3014,7 +3048,32 @@
           },
           "unit": "watt"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "GPU 0"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -3047,7 +3106,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_power_usage{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}",
+          "expr": "dcgm_fi_dev_power_usage{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3150,7 +3209,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "dcgm_fi_dev_total_energy_consumption{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"} / 10^3",
+          "expr": "dcgm_fi_dev_total_energy_consumption{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"} / 10^3",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3264,7 +3323,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_XID_ERRORS{hostname=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_XID_ERRORS{hostname=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -3486,7 +3545,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{hostname=\"$instance\",cluster=\"$cluster\"}",
+          "expr": "DCGM_FI_DEV_CLOCKS_EVENT_REASONS{hostname=~\"^$instance$\",cluster=\"$cluster\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -3705,7 +3764,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_agg_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -3871,7 +3930,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_agg_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4036,7 +4095,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_sbe_vol_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4202,7 +4261,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_ecc_dbe_vol_total{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4338,7 +4397,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_thermal_violation{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_thermal_violation{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4440,7 +4499,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "increase(dcgm_fi_dev_power_violation{hostname=~\"$instance\", gpu=~\"$gpu\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
+          "expr": "increase(dcgm_fi_dev_power_violation{hostname=~\"^$instance$\", gpu=~\"^$gpu$\",cluster=\"$cluster\"}[$__rate_interval]) / 1e9",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -4578,7 +4637,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "node_infiniband_physical_state_id{instance=~\"$instance\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
+          "expr": "node_infiniband_physical_state_id{instance=~\"^$instance$\", device!=\"mlx5_an0\",cluster=\"$cluster\"}",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -4680,7 +4739,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=\"$instance\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(node_infiniband_link_downed_total{instance=~\"^$instance$\",cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval]), 1)",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -4797,7 +4856,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_received_bytes_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{device}} - receive",
           "range": true,
@@ -4809,7 +4868,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$instance\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"^$instance$\", cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "{{device}} - transmit",
@@ -4912,7 +4971,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_errors_received_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5013,7 +5072,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_received_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5114,7 +5173,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "rate(node_infiniband_port_transmit_wait_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5215,7 +5274,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"$instance\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_constraint_errors_transmitted_total{instance=~\"^$instance$\",cluster=\"$cluster\", device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5316,7 +5375,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"$instance\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
+          "expr": "increase(node_infiniband_port_discards_transmitted_total{instance=~\"^$instance$\", cluster=\"$cluster\",device!=\"mlx5_an0\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -5445,7 +5504,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{hostname=\"$instance\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
+          "expr": "clamp_max(increase(dcgm_fi_dev_nvlink_count_link_recovery_failed_events{hostname=~\"^$instance$\",cluster=\"$cluster\"}[$__rate_interval]), 1)",
           "format": "table",
           "instant": false,
           "legendFormat": "{{instance}}",
@@ -5667,7 +5726,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{hostname=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_local_link_integrity_errors{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -5820,7 +5879,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{hostname=~\"$instance\", cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_rx_bytes{hostname=~\"^$instance$\", cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}} - receive",
           "range": true,
           "refId": "A"
@@ -5831,7 +5890,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{hostname=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "rate(dcgm_fi_prof_nvlink_tx_bytes{hostname=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "GPU {{gpu}} - transmit",
@@ -5965,7 +6024,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{hostname=~\"$instance\",cluster=\"$cluster\", gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_rx_errors{hostname=~\"^$instance$\",cluster=\"$cluster\", gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6131,7 +6190,7 @@
             "uid": "${Datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{hostname=~\"$instance\", cluster=\"$cluster\",gpu=~\"$gpu\"}[$__rate_interval])",
+          "expr": "increase(dcgm_fi_dev_nvlink_count_tx_discards{hostname=~\"^$instance$\", cluster=\"$cluster\",gpu=~\"^$gpu$\"}[$__rate_interval])",
           "legendFormat": "GPU {{gpu}}",
           "range": true,
           "refId": "A"
@@ -6206,8 +6265,8 @@
       {
         "current": {
           "selected": true,
-          "text": "da-aks-cluster4-hpcsku",
-          "value": "da-aks-cluster4-hpcsku"
+          "text": "da-hpc-cluster",
+          "value": "da-hpc-cluster"
         },
         "datasource": {
           "type": "prometheus",
@@ -6234,8 +6293,8 @@
       {
         "current": {
           "selected": true,
-          "text": "aks-agentpool-38703046-vmss000001",
-          "value": "aks-agentpool-38703046-vmss000001"
+          "text": "aks-hpcsku-28720227-vmss000000",
+          "value": "aks-hpcsku-28720227-vmss000000"
         },
         "datasource": {
           "type": "prometheus",
@@ -6338,7 +6397,7 @@
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"}, gpu)",
+        "definition": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"},gpu)",
         "hide": 0,
         "includeAll": true,
         "label": "GPU",
@@ -6346,8 +6405,9 @@
         "name": "gpu",
         "options": [],
         "query": {
-          "query": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"}, gpu)",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(dcgm_fi_dev_gpu_util{hostname=\"$instance\"},gpu)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -6357,10 +6417,9 @@
       },
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"10.244.4.112:9400\",job=\"dcgm-nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",service=\"dcgm-nvidia-dcgm-exporter\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}",
+          "value": "dcgm_fi_dev_power_mgmt_limit{cluster=\"da-hpc-cluster\",container=\"exporter\",device=\"nvidia0\",endpoint=\"metrics\",gpu=\"0\",hostname=\"aks-hpcsku-28720227-vmss000000\",instance=\"10.244.4.112:9400\",job=\"dcgm-nvidia-dcgm-exporter\",modelname=\"nvidia a100 80gb pcie\",namespace=\"default\",pci_bus_id=\"00000001:00:00.0\",pod=\"dcgm-nvidia-dcgm-exporter-9cvzq\",service=\"dcgm-nvidia-dcgm-exporter\",uuid=\"gpu-c8cbbf1b-463c-ad59-15e3-8b3f8e46c39d\"}"
         },
         "datasource": {
           "type": "prometheus",
@@ -6394,7 +6453,7 @@
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",hostname=\"$instance\"}",
+        "definition": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",instance=\"$instance\"}",
         "hide": 2,
         "includeAll": false,
         "multi": false,
@@ -6402,7 +6461,7 @@
         "options": [],
         "query": {
           "qryType": 5,
-          "query": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",hostname=\"$instance\"}",
+          "query": "dcgm_fi_dev_power_mgmt_limit{gpu=\"0\",instance=\"$instance\"}",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -6422,7 +6481,7 @@
           "type": "prometheus",
           "uid": "${Datasource}"
         },
-        "definition": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", hostname=\"$instance\"},physical_host)",
+        "definition": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", instance=\"$instance\"},physical_host)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
@@ -6430,7 +6489,7 @@
         "options": [],
         "query": {
           "qryType": 5,
-          "query": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", hostname=\"$instance\"},physical_host)",
+          "query": "label_values(dcgm_fi_dev_power_mgmt_limit{gpu=\"0\", instance=\"$instance\"},physical_host)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/internal/cluster_view.json
+++ b/internal/cluster_view.json
@@ -1,0 +1,4120 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 291,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    TotalClusters = dcount(Tenant),\r\n    NodesinService = dcountif(NodeId,IsNodeInService == true),\r\n    AllocatedNodes = dcountif(NodeId,IsNodeInService == true and IsHEN == false)\r\n    //CustomerNodes = dcountif(NodeId,IsNodeInService == true and IsCustomer== true)\r\n\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Fleet Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "AllocatedNodes": 3,
+              "NodesinService": 2,
+              "TotalClusters": 0,
+              "TotalNodes": 1
+            },
+            "renameByName": {
+              "AllocatedNodes": "Allocated Nodes",
+              "NodesinService": "Nodes In Service",
+              "TotalClusters": "Total Number of Clusters",
+              "TotalNodes": "Total Number Of Nodes"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "// Use fixed reference time like your inspiration query\r\nlet reference_time = now();\r\nlet last_month = reference_time - 30d;\r\nlet last_week = reference_time - 7d;\r\nlet last_day = reference_time - 1d;\r\n\r\nlet base_filter = cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" and IsUtilityNode == false and CloudName == \"Public\"\r\n| where Region in~ ($region) | where Platform in~ ($platform) | where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter) | where Tenant in~ ($cluster);\r\n\r\n// Current data (using TimeWindowEnd like your inspiration)\r\nlet current_data = base_filter\r\n| where TimeWindowEnd between (reference_time - 4h .. reference_time)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Yesterday data (same pattern as inspiration)\r\nlet yesterday_data = base_filter\r\n| where TimeWindowEnd between (bin(last_day, 1d) .. bin(last_day, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Last week data\r\nlet last_week_data = base_filter\r\n| where TimeWindowEnd between (bin(last_week, 1d) .. bin(last_week, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Last month data\r\nlet last_month_data = base_filter\r\n| where TimeWindowEnd between (bin(last_month, 1d) .. bin(last_month, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Calculate changes\r\nlet current_nis = toscalar(current_data | project NIS_Percent);\r\nlet yesterday_nis = toscalar(yesterday_data | project NIS_Percent);\r\nlet last_week_nis = toscalar(last_week_data | project NIS_Percent);\r\nlet last_month_nis = toscalar(last_month_data | project NIS_Percent);\r\n\r\nprint \r\n    DoD = round(current_nis - yesterday_nis, 2),\r\n    WoW = round(current_nis - last_week_nis, 2),\r\n    MoM = round(current_nis - last_month_nis, 2)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Nodes In Service (NIS) Change (%)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "AllocatedNodes": 3,
+              "NodesinService": 2,
+              "TotalClusters": 0,
+              "TotalNodes": 1
+            },
+            "renameByName": {
+              "AllocatedNodes": "Allocated Nodes",
+              "NodesinService": "Nodes In Service",
+              "TotalClusters": "Total Number of Clusters",
+              "TotalNodes": "Total Number Of Nodes"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 5
+              },
+              {
+                "color": "#EF843C",
+                "value": 10
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 15
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n//| where SnapshotTime > ago(24h)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    OFRCount = dcountif(NodeId,State == \"OFR\"),\r\n    InfinibandCount = dcountif(NodeId,State == \"InfiniBand RCA\"),\r\n    TransitionCount = dcountif(NodeId,State == \"Transition\"),\r\n    ValidationCount = dcountif(NodeId,State == \"Validation\")\r\n| extend OFR = 100.0 * OFRCount / TotalNodes\r\n| extend Infiniband = 100.0 * InfinibandCount / TotalNodes\r\n| extend Transition = 100.0 * TransitionCount / TotalNodes\r\n| extend Validation = 100.0 * ValidationCount / TotalNodes\r\n| project OFR, Infiniband, Transition, Validation",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "OOS Breakdown",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "NIS"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Infiniband": 2,
+              "OFR": 0,
+              "Transition": 3,
+              "Validation": 1
+            },
+            "renameByName": {
+              "HEN": "% HEN",
+              "Infiniband": "Infiniband RCA",
+              "MTRA": "",
+              "NIS": "% NIS",
+              "OFR": "Out for Repair",
+              "SLAStatus": "SLA Status",
+              "Transition": "Transition",
+              "Validation": "HPC Perfgate Validation"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Nodes In Service(NIS)"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 0,
+                      "result": {
+                        "color": "red",
+                        "index": 0
+                      },
+                      "to": 95
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "from": 95,
+                      "result": {
+                        "color": "green",
+                        "index": 1
+                      },
+                      "to": 100
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "At Risk": {
+                        "color": "red",
+                        "index": 1
+                      },
+                      "Healthy": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 38,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    NodesInService = dcountif(NodeId, IsNodeInService == true),\r\n    HealthyEmptyNodes = dcountif(NodeId, IsHEN == true)\r\n    by Platform\r\n| extend \r\n    NIS = round(100.0 * NodesInService / TotalNodes, 1),\r\n    HEN = round(100.0 * HealthyEmptyNodes / TotalNodes, 1)\r\n| extend \r\n    SLA95Count = ceiling(TotalNodes * 0.95),  // 95% of total nodes\r\n    NodeDelta95 = NodesInService - ceiling(TotalNodes * 0.95)  // How many nodes above/below 95%\r\n| extend SLAStatus = iff(NIS < 95, \"At Risk\", \"Healthy\")\r\n| project Platform, NIS, HEN, NodeDelta95, SLAStatus, TotalNodes, NodesInService, SLA95Count",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Platform Health Summary",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "NIS"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "NodesInService": true,
+              "SLA95Count": true,
+              "TotalNodes": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "HEN": "% Healthy Empty Nodes (HEN)",
+              "MTRA": "",
+              "NIS": "% Nodes In Service (NIS)",
+              "NodeDelta95": "95% SLA Node Delta",
+              "SLAStatus": "SLA Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Gbits"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "// Use Grafana time range and filters\r\nlet _endTime = $__timeTo();\r\nlet _startTime = $__timeFrom();\r\n\r\n// Determine bin size based on time range\r\nlet binSize = case(\r\n    _endTime - _startTime <= 6h, 1m,\r\n    _endTime - _startTime <= 24h, 3m,\r\n    _endTime - _startTime <= 2d, 6m,\r\n    _endTime - _startTime <= 14d, 42m,\r\n    2h\r\n);\r\nlet window = binSize/1s;\r\n\r\n// Get clusters from your filters\r\nlet _clustersInFabric = cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Tenant;\r\n\r\n// HCA Traffic\r\ncluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where PreciseTimeStamp between (_startTime .. _endTime)\r\n| where Tenant in (_clustersInFabric)\r\n| extend TimeBucket = bin(RowTimeStamp, binSize)\r\n| summarize HCA_Throughput_Gbps = round(sum(Bytes_Sent)*8/(window*1e9), 2) by TimeBucket\r\n| project Time = TimeBucket, value = HCA_Throughput_Gbps\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "OpenAI": false,
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": true,
+          "pluginVersion": "6.0.1",
+          "query": "// Use Grafana time range and filters\r\nlet _endTime = $__timeTo();\r\nlet _startTime = $__timeFrom();\r\n\r\n// Determine bin size based on time range (same as Query A)\r\nlet binSize = case(\r\n    _endTime - _startTime <= 6h, 1m,\r\n    _endTime - _startTime <= 24h, 3m,\r\n    _endTime - _startTime <= 2d, 6m,\r\n    _endTime - _startTime <= 14d, 42m,\r\n    2h\r\n);\r\n\r\n// SM Log Volume - try direct syslog table access\r\ncluster('azurehpc-public.centralus.kusto.windows.net').database('hpcinterconnect').UnionOfAllLogs(\"syslog\", \"SyslogData_Mapped\")\r\n| where TimeGenerated between (_startTime .. _endTime)\r\n| where substring(Computer, 0, 3) in ($datacenter)  // Filter by datacenter\r\n| where Computer contains \"ufm\"  // UFM devices\r\n| where SyslogMessage contains \"OpenSM\"  // OpenSM log entries\r\n| extend TimeBucket = bin(TimeGenerated, binSize)\r\n| summarize OpenSM_LogCount = count() by TimeBucket\r\n| project Time = TimeBucket, value = OpenSM_LogCount\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Aggregate HCA Traffic Egress",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Node Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AllocationStatus"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 1,
+                        "text": "Not Allocated"
+                      },
+                      "1": {
+                        "index": 0,
+                        "text": "Is Allocated"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HealthStatus"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 1,
+                        "text": "Unhealthy Empty Node"
+                      },
+                      "1": {
+                        "index": 0,
+                        "text": "Healthy Empty Node"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 36
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where NodeId == '$node_id'\r\n| extend \r\n    VMCreationTime = todatetime(VirtualMachineCreationTime),\r\n    LiveDate = todatetime(LIVEDate),\r\n    NodeUptime = iff(isnotempty(todatetime(LIVEDate)), datetime_diff('day', now(), todatetime(LIVEDate)), 0),\r\n    VMUptime = iff(isnotempty(todatetime(VirtualMachineCreationTime)), datetime_diff('day', now(), todatetime(VirtualMachineCreationTime)), 0),\r\n    AllocationStatus = iff(IsNodeInService == true and IsHEN == false, 1, 0),\r\n    HealthStatus = iff(IsNodeInService == true and IsHEN == true, 1, 0)\r\n| summarize \r\n    // NodeUptimeDays = max(NodeUptime),\r\n    // VMUptimeDays = max(VMUptime),\r\n    AllocationStatus = max(AllocationStatus),\r\n    HealthStatus = max(HealthStatus)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Node Health ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "NodeUptimeDays": "Node Uptime",
+              "VMUptimeDays": "VM Uptime"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 36
+      },
+      "id": 18,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName in (\"GPU-TEMP-GB-GPU\", \"GPU-TEMP-TLIMIT\")\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| where isfinite(TelemetryValueNum)  // Filter out NaN values\r\n| summarize \r\n    CurrentTemp = case(\r\n        \"$aggregation\" == \"avg\", avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        \"$aggregation\" == \"max\", maxif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        \"$aggregation\" == \"min\", minif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\")\r\n    ),\r\n    TempCountdown = avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-TLIMIT\")\r\n| extend ThrottleThreshold = CurrentTemp + TempCountdown\r\n| extend value = case(\r\n    isnan(CurrentTemp) or isnan(TempCountdown) or ThrottleThreshold <= 0, 0.0,\r\n    (CurrentTemp / ThrottleThreshold) * 100\r\n)\r\n| project value",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU Temp Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 36
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName in (\"GPU-PWR-CURR\", \"GPU-PWR-LIMIT-TOTAL-MAX\")\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| where isfinite(TelemetryValueNum)  // Filter out NaN/infinite values\r\n| summarize \r\n    PowerCurrent = case(\r\n        \"$aggregation\" == \"avg\", avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        \"$aggregation\" == \"max\", maxif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        \"$aggregation\" == \"min\", minif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\")\r\n    ),\r\n    PowerLimit = avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-LIMIT-TOTAL-MAX\")\r\n| extend value = case(\r\n    isnan(PowerCurrent) or isnan(PowerLimit) or PowerLimit <= 0, 0.0,\r\n    (PowerCurrent/PowerLimit)*100\r\n)\r\n| project value",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU Power Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 36
+      },
+      "id": 19,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-UTIL-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize gpu_util = case(\r\n    \"$aggregation\" == \"avg\", avg(TelemetryValueNum),\r\n    \"$aggregation\" == \"max\", max(TelemetryValueNum),\r\n    \"$aggregation\" == \"min\", min(TelemetryValueNum),\r\n    avg(TelemetryValueNum)  // default fallback\r\n)\r\n| project value = gpu_util",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU SM Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 39
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where NodeId == '$node_id'\r\n| extend \r\n    VMCreationTime = todatetime(VirtualMachineCreationTime),\r\n    LiveDate = todatetime(LIVEDate),\r\n    NodeUptime = iff(isnotempty(todatetime(LIVEDate)), datetime_diff('day', now(), todatetime(LIVEDate)), 0),\r\n    VMUptime = iff(isnotempty(todatetime(VirtualMachineCreationTime)), datetime_diff('day', now(), todatetime(VirtualMachineCreationTime)), 0)\r\n| summarize \r\n    NodeUptimeDays = max(NodeUptime),\r\n    VMUptimeDays = max(VMUptime)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Uptime (Days)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "NodeUptimeDays": "Node Uptime",
+              "VMUptimeDays": "VM Uptime"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CLK-THROTTLE-REASON\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last GPU Clock Throttle Events",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "Throttle Event Code"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last GPU Health Status",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "GPU Health Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 25,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-STATUS\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last NVLink Status",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "GPU Health Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 6,
+      "panels": [],
+      "title": "GPU",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-CURR-CLK-MEM\"\r\n// | where ResourceId == '$node_id'\r\n// | extend TelemetryValueNum = todouble(TelemetryValue)\r\n// | project Time = TelemetryTimestamp, InstanceId, value = TelemetryValueNum\r\n// | order by Time asc\r\nRackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CURR-CLK-MEM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Memory Clock",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-UTIL-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU SM Utilization",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-TEMP-MEM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Memory Temp",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CURR-CLK-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU SM Clock",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-PWR-CURR\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Power Usage",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-TEMP-GB-GPU\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Temperature",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-ECC-ERR-CTR-CE\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "SBE Persistent ECC Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "joule"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CTR-ENERGY\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = (avg_TelemetryValueNum / 10e3)\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Total Energy Consumption",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-ECC-ERR-CTR-UCE\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DBE Persistent ECC Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Infiniband",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes out (-) / in (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Bytes_Received)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| extend NicNameWithDirection = strcat(NicName, \" - receive\")\r\n| project Time = PreciseTimeStamp, NicName = NicNameWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Bytes_Sent)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| extend NicNameWithDirection = strcat(NicName, \" - sent\")\r\n| project Time = PreciseTimeStamp, NicName = NicNameWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "IB Throughput (RX/TX)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Received_Errors)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Rcv Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Outbound_Errors)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Xmit Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 104
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Outbound_Discarded)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Xmit Discards",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 112
+      },
+      "id": 23,
+      "panels": [],
+      "title": "NVLink",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes out (-) / in (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 113
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-THROUGHPUT-RX\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| extend InstanceIdWithDirection = strcat(InstanceId, \" - receive\")\r\n| project Time = TelemetryTimestamp, InstanceId = InstanceIdWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-THROUGHPUT-TX\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| extend InstanceIdWithDirection = strcat(InstanceId, \" - transmit\")\r\n| project Time = TelemetryTimestamp, InstanceId = InstanceIdWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "NVLink Throughput (RX/TX)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+        "hide": 0,
+        "includeAll": true,
+        "label": "region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "datacenter",
+        "multi": true,
+        "name": "datacenter",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "customer",
+        "multi": true,
+        "name": "customer",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "platform",
+        "multi": true,
+        "name": "platform",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "08e715ed-bfbf-7859-36ec-afbb061e214f",
+          "value": "08e715ed-bfbf-7859-36ec-afbb061e214f"
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| where Platform in~ ($platform)\r\n| where IsNodeInService == true\r\n| distinct NodeId\r\n| order by NodeId asc\r\n",
+        "hide": 0,
+        "includeAll": false,
+        "label": "node_id",
+        "multi": false,
+        "name": "node_id",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| where Platform in~ ($platform)\r\n| where IsNodeInService == true\r\n| distinct NodeId\r\n| order by NodeId asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "max",
+          "value": "max"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "aggregation",
+        "options": [
+          {
+            "selected": false,
+            "text": "avg",
+            "value": "avg"
+          },
+          {
+            "selected": true,
+            "text": "max",
+            "value": "max"
+          },
+          {
+            "selected": false,
+            "text": "min",
+            "value": "min"
+          }
+        ],
+        "query": "avg,max,min",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6M",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Cluster View",
+  "uid": "cemixfipo7hfkacluster",
+  "version": 4,
+  "weekStart": ""
+}

--- a/internal/fleet_view.json
+++ b/internal/fleet_view.json
@@ -1,0 +1,1386 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 287,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    TotalClusters = dcount(Tenant),\r\n    NodesinService = dcountif(NodeId,IsNodeInService == true),\r\n    AllocatedNodes = dcountif(NodeId,IsNodeInService == true and IsHEN == false)\r\n    //CustomerNodes = dcountif(NodeId,IsNodeInService == true and IsCustomer== true)\r\n\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Fleet Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "AllocatedNodes": 3,
+              "NodesinService": 2,
+              "TotalClusters": 0,
+              "TotalNodes": 1
+            },
+            "renameByName": {
+              "AllocatedNodes": "Allocated Nodes",
+              "NodesinService": "Nodes In Service",
+              "TotalClusters": "Total Number of Clusters",
+              "TotalNodes": "Total Number Of Nodes"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "// Use fixed reference time like your inspiration query\r\nlet reference_time = now();\r\nlet last_month = reference_time - 30d;\r\nlet last_week = reference_time - 7d;\r\nlet last_day = reference_time - 1d;\r\n\r\nlet base_filter = cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" and IsUtilityNode == false and CloudName == \"Public\"\r\n| where Region in~ ($region) | where Platform in~ ($platform) | where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter) | where Tenant in~ ($cluster);\r\n\r\n// Current data (using TimeWindowEnd like your inspiration)\r\nlet current_data = base_filter\r\n| where TimeWindowEnd between (reference_time - 4h .. reference_time)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Yesterday data (same pattern as inspiration)\r\nlet yesterday_data = base_filter\r\n| where TimeWindowEnd between (bin(last_day, 1d) .. bin(last_day, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Last week data\r\nlet last_week_data = base_filter\r\n| where TimeWindowEnd between (bin(last_week, 1d) .. bin(last_week, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Last month data\r\nlet last_month_data = base_filter\r\n| where TimeWindowEnd between (bin(last_month, 1d) .. bin(last_month, 1d) + 1d)\r\n| summarize arg_max(TimeWindowEnd, *) by NodeId\r\n| summarize Total = count(), NISCount = countif(IsNodeInService)\r\n| extend NIS_Percent = iff(Total > 0, round(NISCount / todouble(Total) * 100, 2), 0.0);\r\n\r\n// Calculate changes\r\nlet current_nis = toscalar(current_data | project NIS_Percent);\r\nlet yesterday_nis = toscalar(yesterday_data | project NIS_Percent);\r\nlet last_week_nis = toscalar(last_week_data | project NIS_Percent);\r\nlet last_month_nis = toscalar(last_month_data | project NIS_Percent);\r\n\r\nprint \r\n    DoD = round(current_nis - yesterday_nis, 2),\r\n    WoW = round(current_nis - last_week_nis, 2),\r\n    MoM = round(current_nis - last_month_nis, 2)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Nodes In Service (NIS) Change (%)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "AllocatedNodes": 3,
+              "NodesinService": 2,
+              "TotalClusters": 0,
+              "TotalNodes": 1
+            },
+            "renameByName": {
+              "AllocatedNodes": "Allocated Nodes",
+              "NodesinService": "Nodes In Service",
+              "TotalClusters": "Total Number of Clusters",
+              "TotalNodes": "Total Number Of Nodes"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 5
+              },
+              {
+                "color": "#EF843C",
+                "value": 10
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 15
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 6,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n//| where SnapshotTime > ago(24h)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    OFRCount = dcountif(NodeId,State == \"OFR\"),\r\n    InfinibandCount = dcountif(NodeId,State == \"InfiniBand RCA\"),\r\n    TransitionCount = dcountif(NodeId,State == \"Transition\"),\r\n    ValidationCount = dcountif(NodeId,State == \"Validation\")\r\n| extend OFR = 100.0 * OFRCount / TotalNodes\r\n| extend Infiniband = 100.0 * InfinibandCount / TotalNodes\r\n| extend Transition = 100.0 * TransitionCount / TotalNodes\r\n| extend Validation = 100.0 * ValidationCount / TotalNodes\r\n| project OFR, Infiniband, Transition, Validation",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Out of Service (OOS) Breakdown",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "NIS"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Infiniband": 2,
+              "OFR": 0,
+              "Transition": 3,
+              "Validation": 1
+            },
+            "renameByName": {
+              "HEN": "% HEN",
+              "Infiniband": "Infiniband RCA",
+              "MTRA": "",
+              "NIS": "% NIS",
+              "OFR": "Out for Repair",
+              "SLAStatus": "SLA Status",
+              "Transition": "Transition",
+              "Validation": "HPC Perfgate Validation"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Nodes In Service(NIS)"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 0,
+                      "result": {
+                        "color": "red",
+                        "index": 0
+                      },
+                      "to": 95
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "from": 95,
+                      "result": {
+                        "color": "green",
+                        "index": 1
+                      },
+                      "to": 100
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "At Risk": {
+                        "color": "red",
+                        "index": 1
+                      },
+                      "Healthy": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where NodeCategory == \"Compute\" \r\n    and IsUtilityNode == false\r\n    and CloudName == \"Public\"\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| summarize \r\n    TotalNodes = dcount(NodeId),\r\n    NodesInService = dcountif(NodeId, IsNodeInService == true),\r\n    HealthyEmptyNodes = dcountif(NodeId, IsHEN == true)\r\n    by Platform\r\n| extend \r\n    NIS = round(100.0 * NodesInService / TotalNodes, 1),\r\n    HEN = round(100.0 * HealthyEmptyNodes / TotalNodes, 1)\r\n| extend \r\n    SLA95Count = ceiling(TotalNodes * 0.95),  // 95% of total nodes\r\n    NodeDelta95 = NodesInService - ceiling(TotalNodes * 0.95)  // How many nodes above/below 95%\r\n| extend SLAStatus = iff(NIS < 95, \"At Risk\", \"Healthy\")\r\n| project Platform, NIS, HEN, NodeDelta95, SLAStatus, TotalNodes, NodesInService, SLA95Count",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Platform Health Summary",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "NIS"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "NodesInService": true,
+              "SLA95Count": true,
+              "TotalNodes": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "HEN": "% Healthy Empty Nodes (HEN)",
+              "MTRA": "",
+              "NIS": "% Nodes In Service (NIS)",
+              "NodeDelta95": "95% SLA Node Delta",
+              "SLAStatus": "SLA Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Nodes In Service(NIS)"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 0,
+                      "result": {
+                        "color": "red",
+                        "index": 0
+                      },
+                      "to": 95
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "from": 95,
+                      "result": {
+                        "color": "green",
+                        "index": 1
+                      },
+                      "to": 100
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "At Risk": {
+                        "color": "red",
+                        "index": 1
+                      },
+                      "Healthy": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fault Description"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 204
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "// cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n// | where $__timeFilter(SnapshotTime)\r\n// | where Region in~ ($region) \r\n// | where Platform in~ ($platform) \r\n// | where Customer in~ ($customer) \r\n// | where FaultCode > 0 \r\n// | where substring(Tenant, 0, 3) in ($datacenter) \r\n// | where Tenant in~ ($cluster)\r\n// | where IsNodeInService == false \r\n// | summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n// | extend FaultCategory = case(\r\n//     FaultCode between (0 .. 9999), \"Auto-generated OFR by FC\",\r\n//     FaultCode between (10000 .. 19999), \"Auto-generated HI by FC\", \r\n//     FaultCode between (20000 .. 29999), \"Internal Investigation\",\r\n//     FaultCode == 30151, \"Internal RCA - Reboots/Bugchecks\",\r\n//     FaultCode between (32000 .. 32999), \"Internal RCA - CSI Reserved\",\r\n//     FaultCode between (34401 .. 34499), \"Internal RCA - Bugcheck\",\r\n//     FaultCode between (60000 .. 60999), \"Hardware RMA\",\r\n//     FaultCode between (61000 .. 61999), \"Vendor Attention\",\r\n//     FaultCode between (62000 .. 62999), \"CSI Diag RMA\",\r\n//     FaultCode between (63000 .. 63999), \"Non-CSI Diag RMA\",\r\n//     FaultCode between (70000 .. 70009), \"Repeat Failer\",\r\n//     FaultCode > 70009, \"Special Fault Codes\",\r\n//     \"Unknown\"\r\n// )\r\n// | summarize \r\n// FaultCount = dcount(NodeId),\r\n// TotalOccurrences = count()\r\n// by Platform, FaultDescription, FaultCode, FaultCategory\r\n// | partition by Platform (sort by FaultCount desc | take $top_n_faults)\r\n// | join kind=leftouter (\r\n//     cluster('hqse.kusto.windows.net').database('hqsedb').external_table('MoAD_RedlineFaultCodes')\r\n//     | project FaultCode, SP3FaultReason, SourceTeam, SMETeam\r\n// ) on FaultCode\r\n// | project Platform, FaultDescription, FaultCount, FaultCode, FaultCategory, SP3FaultReason, SourceTeam, SMETeam\r\n// | sort by Platform, FaultCount desc\r\ncluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region) \r\n| where Platform in~ ($platform) \r\n| where Customer in~ ($customer) \r\n| where FaultCode > 0 \r\n| where substring(Tenant, 0, 3) in ($datacenter) \r\n| where Tenant in~ ($cluster)\r\n| where IsNodeInService == false \r\n//| summarize arg_max(TimeWindowStart, QueryTime, *) by NodeId\r\n| extend FaultCategory = case(\r\n    FaultCode between (0 .. 9999), \"Auto-generated OFR by FC\",\r\n    FaultCode between (10000 .. 19999), \"Auto-generated HI by FC\", \r\n    FaultCode between (20000 .. 29999), \"Internal Investigation\",\r\n    FaultCode == 30151, \"Internal RCA - Reboots/Bugchecks\",\r\n    FaultCode between (32000 .. 32999), \"Internal RCA - CSI Reserved\",\r\n    FaultCode between (34401 .. 34499), \"Internal RCA - Bugcheck\",\r\n    FaultCode between (60000 .. 60999), \"Hardware RMA\",\r\n    FaultCode between (61000 .. 61999), \"Vendor Attention\",\r\n    FaultCode between (62000 .. 62999), \"CSI Diag RMA\",\r\n    FaultCode between (63000 .. 63999), \"Non-CSI Diag RMA\",\r\n    FaultCode between (70000 .. 70009), \"Repeat Failer\",\r\n    FaultCode > 70009, \"Special Fault Codes\",\r\n    \"Unknown\"\r\n)\r\n| summarize \r\n    FaultCount = dcount(NodeId),\r\n    TotalOccurrences = count(),\r\n    SampleFaultDescription = take_any(FaultDescription)  // Get one example description\r\n    by Platform, FaultCode, FaultCategory\r\n| partition by Platform (sort by FaultCount desc | take $top_n_faults)\r\n| join kind=leftouter (\r\n    cluster('hqse.kusto.windows.net').database('hqsedb').external_table('MoAD_RedlineFaultCodes')\r\n    | project FaultCode, SP3FaultReason, SourceTeam, SMETeam\r\n) on FaultCode\r\n| project Platform, FaultCode, FaultCount, FaultCategory, SampleFaultDescription, SP3FaultReason, SourceTeam, SMETeam\r\n| sort by Platform, FaultCount desc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Top $top_n_faults DCM Faults per Platform",
+      "transformations": [
+        {
+          "disabled": true,
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "FaultCount"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Rank": true,
+              "SourceTeam": true,
+              "dummy": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "FaultCategory": 2,
+              "FaultCode": 1,
+              "FaultCount": 5,
+              "Platform": 0,
+              "SMETeam": 7,
+              "SP3FaultReason": 3,
+              "SampleFaultDescription": 4,
+              "SourceTeam": 6
+            },
+            "renameByName": {
+              "FaultCategory": "Fault Category",
+              "FaultCode": "Fault Code",
+              "FaultCount": "Fault Count",
+              "FaultDescription": "Fault Description",
+              "MTRA": "",
+              "NIS": "Nodes In Service(NIS)",
+              "SLAStatus": "SLA Status",
+              "SMETeam": "SME Team",
+              "SP3FaultReason": "Fault Reason",
+              "SampleFaultDescription": "Fault Description",
+              "SourceTeam": "Source Team",
+              "TotalOccurrences": "Total Occurences"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Nodes In Service(NIS)"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 0,
+                      "result": {
+                        "color": "red",
+                        "index": 0
+                      },
+                      "to": 95
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "from": 95,
+                      "result": {
+                        "color": "green",
+                        "index": 1
+                      },
+                      "to": 100
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "At Risk": {
+                        "color": "red",
+                        "index": 1
+                      },
+                      "Healthy": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Fault Description"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 204
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "clusterUri": "https://sparkle.eastus.kusto.windows.net/",
+          "database": "blobstreamingdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcguesthealthsignals.eastus.kusto.windows.net').database('guesthealthreporting-telemetry').VmRequestDetails\r\n| where $__timeFilter(PreciseTimestamp)\r\n| where ObservationStatus != \"Healthy\"\r\n| join kind=inner (\r\n    cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n    | where Region in~ ($region) | where Platform in~ ($platform) | where Customer in~ ($customer)\r\n    | where substring(Tenant, 0, 3) in ($datacenter) | where Tenant in~ ($cluster)\r\n    | summarize arg_max(SnapshotTime, Platform) by NodeId\r\n) on NodeId\r\n| summarize \r\n    IssueCount = dcount(NodeId),\r\n    TotalObservations = count(),\r\n    SampleReason = take_any(RmaReason)\r\n    by Platform, ObservationType, ObservationStatus\r\n| partition by Platform (sort by IssueCount desc | take $top_n_faults)\r\n| sort by Platform, IssueCount desc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Top $top_n_faults GHR Issues per Platform",
+      "transformations": [
+        {
+          "disabled": true,
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "FaultCount"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Rank": true,
+              "SourceTeam": true,
+              "TotalObservations": true,
+              "dummy": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "IssueCount": 4,
+              "ObservationStatus": 3,
+              "ObservationType": 1,
+              "Platform": 0,
+              "SampleReason": 2,
+              "TotalObservations": 5
+            },
+            "renameByName": {
+              "FaultCategory": "Fault Category",
+              "FaultCode": "Fault Code",
+              "FaultCount": "Fault Count",
+              "FaultDescription": "Fault Description",
+              "IssueCount": "Issue Count",
+              "MTRA": "",
+              "NIS": "Nodes In Service(NIS)",
+              "ObservationStatus": "Observation Status",
+              "ObservationType": "Observation Category",
+              "SLAStatus": "SLA Status",
+              "SMETeam": "SME Team",
+              "SP3FaultReason": "Fault Reason",
+              "SampleFaultDescription": "Fault Description",
+              "SampleReason": "Description",
+              "SourceTeam": "Source Team",
+              "TotalObservations": "",
+              "TotalOccurrences": "Total Occurences"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+        "hide": 0,
+        "includeAll": true,
+        "label": "region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "datacenter",
+        "multi": true,
+        "name": "datacenter",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "customer",
+        "multi": true,
+        "name": "customer",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "platform",
+        "multi": true,
+        "name": "platform",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "10",
+          "value": "10"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "top_n_faults",
+        "multi": false,
+        "name": "top_n_faults",
+        "options": [
+          {
+            "selected": false,
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "selected": false,
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "selected": true,
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "selected": false,
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "selected": false,
+            "text": "20",
+            "value": "20"
+          }
+        ],
+        "query": "3,5,10,15,20",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6M",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Fleet View",
+  "uid": "cemixfipo7hfka",
+  "version": 37,
+  "weekStart": ""
+}

--- a/internal/node_view.json
+++ b/internal/node_view.json
@@ -1,0 +1,3541 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 290,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Node Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AllocationStatus"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 1,
+                        "text": "Not Allocated"
+                      },
+                      "1": {
+                        "index": 0,
+                        "text": "Is Allocated"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HealthStatus"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 1,
+                        "text": "Unhealthy Empty Node"
+                      },
+                      "1": {
+                        "index": 0,
+                        "text": "Healthy Empty Node"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where NodeId == '$node_id'\r\n| extend \r\n    VMCreationTime = todatetime(VirtualMachineCreationTime),\r\n    LiveDate = todatetime(LIVEDate),\r\n    NodeUptime = iff(isnotempty(todatetime(LIVEDate)), datetime_diff('day', now(), todatetime(LIVEDate)), 0),\r\n    VMUptime = iff(isnotempty(todatetime(VirtualMachineCreationTime)), datetime_diff('day', now(), todatetime(VirtualMachineCreationTime)), 0),\r\n    AllocationStatus = iff(IsNodeInService == true and IsHEN == false, 1, 0),\r\n    HealthStatus = iff(IsNodeInService == true and IsHEN == true, 1, 0)\r\n| summarize \r\n    // NodeUptimeDays = max(NodeUptime),\r\n    // VMUptimeDays = max(VMUptime),\r\n    AllocationStatus = max(AllocationStatus),\r\n    HealthStatus = max(HealthStatus)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Node Health ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "NodeUptimeDays": "Node Uptime",
+              "VMUptimeDays": "VM Uptime"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName in (\"GPU-TEMP-GB-GPU\", \"GPU-TEMP-TLIMIT\")\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| where isfinite(TelemetryValueNum)  // Filter out NaN values\r\n| summarize \r\n    CurrentTemp = case(\r\n        \"$aggregation\" == \"avg\", avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        \"$aggregation\" == \"max\", maxif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        \"$aggregation\" == \"min\", minif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\"),\r\n        avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-GB-GPU\")\r\n    ),\r\n    TempCountdown = avgif(TelemetryValueNum, TelemetryName == \"GPU-TEMP-TLIMIT\")\r\n| extend ThrottleThreshold = CurrentTemp + TempCountdown\r\n| extend value = case(\r\n    isnan(CurrentTemp) or isnan(TempCountdown) or ThrottleThreshold <= 0, 0.0,\r\n    (CurrentTemp / ThrottleThreshold) * 100\r\n)\r\n| project value",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU Temp Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName in (\"GPU-PWR-CURR\", \"GPU-PWR-LIMIT-TOTAL-MAX\")\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| where isfinite(TelemetryValueNum)  // Filter out NaN/infinite values\r\n| summarize \r\n    PowerCurrent = case(\r\n        \"$aggregation\" == \"avg\", avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        \"$aggregation\" == \"max\", maxif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        \"$aggregation\" == \"min\", minif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\"),\r\n        avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-CURR\")\r\n    ),\r\n    PowerLimit = avgif(TelemetryValueNum, TelemetryName == \"GPU-PWR-LIMIT-TOTAL-MAX\")\r\n| extend value = case(\r\n    isnan(PowerCurrent) or isnan(PowerLimit) or PowerLimit <= 0, 0.0,\r\n    (PowerCurrent/PowerLimit)*100\r\n)\r\n| project value",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU Power Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 19,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-UTIL-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize gpu_util = case(\r\n    \"$aggregation\" == \"avg\", avg(TelemetryValueNum),\r\n    \"$aggregation\" == \"max\", max(TelemetryValueNum),\r\n    \"$aggregation\" == \"min\", min(TelemetryValueNum),\r\n    avg(TelemetryValueNum)  // default fallback\r\n)\r\n| project value = gpu_util",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "GPU SM Utilization ($aggregation)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#6ED0E0",
+                "value": 25
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where $__timeFilter(SnapshotTime)\r\n| where Region in~ ($region)\r\n| where Platform in~ ($platform)\r\n| where Customer in~ ($customer)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where NodeId == '$node_id'\r\n| extend \r\n    VMCreationTime = todatetime(VirtualMachineCreationTime),\r\n    LiveDate = todatetime(LIVEDate),\r\n    NodeUptime = iff(isnotempty(todatetime(LIVEDate)), datetime_diff('day', now(), todatetime(LIVEDate)), 0),\r\n    VMUptime = iff(isnotempty(todatetime(VirtualMachineCreationTime)), datetime_diff('day', now(), todatetime(VirtualMachineCreationTime)), 0)\r\n| summarize \r\n    NodeUptimeDays = max(NodeUptime),\r\n    VMUptimeDays = max(VMUptime)",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Uptime (Days)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "NodeUptimeDays": "Node Uptime",
+              "VMUptimeDays": "VM Uptime"
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CLK-THROTTLE-REASON\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last GPU Clock Throttle Events",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "Throttle Event Code"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last GPU Health Status",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "GPU Health Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1300,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Health Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "OK": {
+                        "color": "green",
+                        "index": 0
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 25,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.2.8",
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-STATUS\"  // Adjust to correct metric name\r\n| where ResourceId == '$node_id'\r\n| summarize arg_max(TelemetryTimestamp, TelemetryValue) by InstanceId\r\n| project \r\n    InstanceId,\r\n    TelemetryValue,\r\n    TelemetryTimestamp\r\n\r\n// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-HEALTH\"  // Adjust to correct metric name\r\n// | where ResourceId == '$node_id'\r\n// | project \r\n//     InstanceId,\r\n//     TelemetryValue",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Last NVLink Status",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "InstanceId"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "TelemetryTimestamp": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "InstanceId": 1,
+              "TelemetryTimestamp": 0,
+              "TelemetryValue": 2
+            },
+            "renameByName": {
+              "InstanceId": "GPU Instance",
+              "TelemetryTimestamp": "Time Stamp",
+              "TelemetryValue": "GPU Health Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 6,
+      "panels": [],
+      "title": "GPU",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-UTIL-GPU\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Utilization",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-UTIL-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU SM Utilization",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "// RackTelemetryGPUTelemetryFull\r\n// | where $__timeFilter(TelemetryTimestamp)\r\n// | where TelemetryName == \"GPU-CURR-CLK-MEM\"\r\n// | where ResourceId == '$node_id'\r\n// | extend TelemetryValueNum = todouble(TelemetryValue)\r\n// | project Time = TelemetryTimestamp, InstanceId, value = TelemetryValueNum\r\n// | order by Time asc\r\nRackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CURR-CLK-MEM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Memory Clock",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CURR-CLK-SM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU SM Clock",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-TEMP-MEM\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Memory Temp",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-TEMP-GB-GPU\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Temperature",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-PWR-CURR\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "GPU Power Usage",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "joule"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-CTR-ENERGY\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = (avg_TelemetryValueNum / 10e3)\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Total Energy Consumption",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-ECC-ERR-CTR-CE\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "SBE Persistent ECC Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-ECC-ERR-CTR-UCE\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| project Time = TelemetryTimestamp, InstanceId, value = avg_TelemetryValueNum\r\n| order by Time asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DBE Persistent ECC Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Infiniband",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes out (-) / in (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Bytes_Received)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| extend NicNameWithDirection = strcat(NicName, \" - receive\")\r\n| project Time = PreciseTimeStamp, NicName = NicNameWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Bytes_Sent)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| extend NicNameWithDirection = strcat(NicName, \" - sent\")\r\n| project Time = PreciseTimeStamp, NicName = NicNameWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "IB Throughput (RX/TX)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Received_Errors)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Rcv Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Outbound_Errors)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Xmit Errors",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('hpcfuntelemetry.eastus').database('HCATelemetry').Mlx5HpcTrafficCounters\r\n| where $__timeFilter(PreciseTimeStamp)\r\n| where NodeId == '$node_id'\r\n| extend TelemetryValueNum = todouble(Packets_Outbound_Discarded)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(PreciseTimeStamp, $__timeInterval), NicName\r\n| project Time = PreciseTimeStamp, NicName, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Port Xmit Discards",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "NicName"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      },
+      "id": 23,
+      "panels": [],
+      "title": "NVLink",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "fem88lm00ugowb"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes out (-) / in (+)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 78
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-THROUGHPUT-RX\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| extend InstanceIdWithDirection = strcat(InstanceId, \" - receive\")\r\n| project Time = TelemetryTimestamp, InstanceId = InstanceIdWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "OpenAI": false,
+          "database": "defaultdb",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "fem88lm00ugowb"
+          },
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "hide": false,
+          "pluginVersion": "5.1.1",
+          "query": "RackTelemetryGPUTelemetryFull\r\n| where $__timeFilter(TelemetryTimestamp)\r\n| where TelemetryName == \"GPU-NVLINK-THROUGHPUT-TX\"\r\n| where ResourceId == '$node_id'\r\n| extend TelemetryValueNum = todouble(TelemetryValue)\r\n| summarize avg_TelemetryValueNum = avg(TelemetryValueNum) by bin(TelemetryTimestamp, $__timeInterval), InstanceId\r\n| extend InstanceIdWithDirection = strcat(InstanceId, \" - transmit\")\r\n| project Time = TelemetryTimestamp, InstanceId = InstanceIdWithDirection, value = avg_TelemetryValueNum\r\n| order by Time asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "NVLink Throughput (RX/TX)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "InstanceId"
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+        "hide": 0,
+        "includeAll": true,
+        "label": "region",
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| distinct Region\r\n| order by Region asc",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "datacenter",
+        "multi": true,
+        "name": "datacenter",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| extend DC = substring(Tenant, 0, 3)\r\n| distinct DC\r\n| order by DC asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| distinct Tenant\r\n| order by Tenant asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "customer",
+        "multi": true,
+        "name": "customer",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| distinct Customer\r\n| order by Customer asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "platform",
+        "multi": true,
+        "name": "platform",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| distinct Platform\r\n| order by Platform asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "08e715ed-bfbf-7859-36ec-afbb061e214f",
+          "value": "08e715ed-bfbf-7859-36ec-afbb061e214f"
+        },
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "fem88lm00ugowb"
+        },
+        "definition": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| where Platform in~ ($platform)\r\n| where IsNodeInService == true\r\n| distinct NodeId\r\n| order by NodeId asc\r\n",
+        "hide": 0,
+        "includeAll": false,
+        "label": "node_id",
+        "multi": false,
+        "name": "node_id",
+        "options": [],
+        "query": {
+          "OpenAI": false,
+          "azureLogAnalytics": {
+            "query": "",
+            "resources": []
+          },
+          "clusterUri": "",
+          "database": "blobstreamingdb",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "5.1.1",
+          "query": "cluster('vmakpi').database('AzureHPCAnalytics').AzureHPC_CapacityBucketDashboard_Snapshot\r\n| where Region in~ ($region)\r\n| where substring(Tenant, 0, 3) in ($datacenter)\r\n| where Tenant in~ ($cluster)\r\n| where Customer in~ ($customer)\r\n| where Platform in~ ($platform)\r\n| where IsNodeInService == true\r\n| distinct NodeId\r\n| order by NodeId asc\r\n",
+          "querySource": "raw",
+          "queryType": "KQL",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table",
+          "subscription": "E3786699-5116-4DC9-82C6-A8AAB043FB85"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "max",
+          "value": "max"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "aggregation",
+        "options": [
+          {
+            "selected": false,
+            "text": "avg",
+            "value": "avg"
+          },
+          {
+            "selected": true,
+            "text": "max",
+            "value": "max"
+          },
+          {
+            "selected": false,
+            "text": "min",
+            "value": "min"
+          }
+        ],
+        "query": "avg,max,min",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6M",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Node View",
+  "uid": "cemixfipo7hfkanode",
+  "version": 14,
+  "weekStart": ""
+}


### PR DESCRIPTION
Issue: Querying for ccw-gpu-1 was also returning results for ccw-gpu-11 and ccw-gpu-101
Cause: Using instance=~"$instance" without anchoring performed substring matching instead of exact matching
Solution: Use either:

instance="$instance" (exact match)
instance=~"^$instance$" (anchored regex)

The regex was matching any instance name containing "ccw-gpu-1" as a substring, rather than matching it exactly.